### PR TITLE
Fix incorrect AutoGPT link

### DIFF
--- a/content/10.introduction.md
+++ b/content/10.introduction.md
@@ -10,7 +10,7 @@ Trained correctly, they can recall and combine virtually limitless knowledge fro
 LLMs have taken the world by storm, and many biomedical researchers already use them in their daily work, for general as well as research tasks [@doi:10.1038/s41586-023-06792-0;@doi:10.1101/2023.04.16.537094;@doi:10.1038/s41587-023-01789-6].
 However, the current way of interacting with LLMs is predominantly manual, virtually non-reproducible, and their behaviour can be erratic.
 For instance, they are known to confabulate: they make up facts as they go along, and, to make matters worse, are convinced — and convincing — regarding the truth of their confabulations [@doi:10.1038/s41586-023-05881-4;@doi:10.1038/s41587-023-01789-6].
-Current efforts towards Artificial General Intelligence have made some progress in addressing these issues by ensembling multiple models [@{https://python.langchain.com}] with long-term memory stores [@{https://autogpt.net/}].
+Current efforts towards Artificial General Intelligence have made some progress in addressing these issues by ensembling multiple models [@{https://python.langchain.com}] with long-term memory stores [@{https://agpt.co/}].
 However, current AI systems have not yet earned sufficient trust for use in biomedical fields [@doi:10.1038/s41586-023-05881-4].
 These areas demand greater care in data privacy, licensing, and transparency than many other issues and cannot be approached without oversight [@doi:10.48550/arXiv.2401.05654].
 


### PR DESCRIPTION
## Fix Details

Update the AutoGPT link in the paper to the official AutoGPT website:

`https://agpt.co/`

## Reason for the Fix

The current link points to an impersonating website unrelated to the official AutoGPT project.

Official AutoGPT project website:
`https://agpt.co/`

Official GitHub repository (for verification):
`https://github.com/Significant-Gravitas/AutoGPT`

## Changes Made

* Replace incorrect link in the paper with `https://agpt.co/`
